### PR TITLE
Adds link to the index page from subpage to the breadcrumbs.

### DIFF
--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -22,6 +22,10 @@
 {% if page.lesson.material %}
 > <a href="{{ page.lesson.material.session.get_url() }}">{{ page.lesson.material.session.title }}</a>
 {% endif %}
+{% set parent=page.lesson.pages.index %}
+{% if parent and parent != page %}
+> <a href="{{ parent.get_url() }}">{{ parent.title }}</a>
+{% endif %}
 > {{ page.title }}
 {% endblock %}
 


### PR DESCRIPTION
Should resolve #20 . There will be issues in the data, because the solution so far was to duplicate the index page title.