### PR TITLE
Fix a bug when sanitizing `scoped` attribute of style element

### DIFF
--- a/naucse/sanitize.py
+++ b/naucse/sanitize.py
@@ -158,12 +158,6 @@ def sanitize_element(element, *, naucse_urls=None):
             # del element.attrib[attr_name]
             continue
 
-        if (
-            attr_name not in ALLOWED_ATTRIBUTES
-            and attr_name not in PER_TAG_ATTRIBUTES.get(element.tag, ())
-        ):
-            raise DisallowedAttribute(f'{attr_name} on {element.tag}')
-
         if attr_name in {'href', 'src'}:
             element.attrib[attr_name] = convert_link(
                 attr_name, value, naucse_urls=naucse_urls)
@@ -173,6 +167,13 @@ def sanitize_element(element, *, naucse_urls=None):
             # We scope CSS in <style> tags in the validator, so the "scoped"
             # attribute would break browsers that still honor it.
             del element.attrib[attr_name]
+            continue
+
+        if (
+            attr_name not in ALLOWED_ATTRIBUTES
+            and attr_name not in PER_TAG_ATTRIBUTES.get(element.tag, ())
+        ):
+            raise DisallowedAttribute(f'{attr_name} on {element.tag}')
 
     # Recurse
     for child in element:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='naucse',
-    version='0.1',
+    version='0.1.1',
     description='Website for course materials',
     long_description=Path('README.md').read_text(),
     long_description_content_type='text/markdown',

--- a/test_naucse/test_validation.py
+++ b/test_naucse/test_validation.py
@@ -126,6 +126,32 @@ def test_scope_multiple_css_selectors():
             }</style>
     """)
 
+def test_style_scoped():
+    assert_changed("""
+        <style scoped id="my-style">
+        .dataframe {
+            color: red;
+        }
+        </style>
+    """, """
+        <style id="my-style">.lesson-content .dataframe {
+            color: red
+            }</style>
+    """)
+
+def test_style_scoped_value():
+    assert_changed("""
+        <style id="my-style" scoped="scoped">
+        .dataframe {
+            color: red;
+        }
+        </style>
+    """, """
+        <style id="my-style">.lesson-content .dataframe {
+            color: red
+            }</style>
+    """)
+
 def test_fix_bad_html():
     # We let lxml do its best to produce valid HTML
     assert_changed(


### PR DESCRIPTION
When sanitizing `scoped` attribute of `<style>` element it makes sense to do it before DisallowedAttribute exception is raised (because scoped is not in sets of allowed attributes) and it also makes sense to `continue` when this attribute is deleted from an element.

I've found this bug because notebook files contains style elements with scoped attibutes.