### PR TITLE
API 0.2 preparation; add page subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a server for open course material.
 
 To use it, you will need some content.
-Usually, the repository with the content will require `naucse` module,
+Usually, the repository with the content will require the `naucse` module,
 and will run using `python -m naucse`.
 
 We use content at https://github.com/pyvec/naucse.python.cz to generate
@@ -12,15 +12,15 @@ We use content at https://github.com/pyvec/naucse.python.cz to generate
 
 ## Installation
 
-Install from a virtual environment (or a tool like pipenv).
+Install from a virtual environment.
 
 To install the latest release:
 
     (venv)$ python -m pip install naucse
 
-To install from a cloned repository:
+To install from a cloned repository, for development:
 
-    (venv)$ python -m pip install -e.
+    (venv)$ python -m pip install -e.[dev]
 
 
 ## Running
@@ -50,7 +50,11 @@ In an isolated environment, you can set `NAUCSE_TRUSTED_REPOS` to `*`
 
 Tests can be run using `tox`:
 
-    $ tox
+    (venv)$ tox
+
+or `pytest` directly:
+
+    (venv)$ python -m pytest
 
 
 ## Licence

--- a/naucse/converters.py
+++ b/naucse/converters.py
@@ -512,18 +512,20 @@ class VersionField(AbstractField):
         version, field = self._field_for_context(context)
         if field:
             field.put_schema_into(object_schema, context)
-            try:
-                schema = object_schema['properties'][self.name]
-            except KeyError:
-                pass
-            if version == self.fields[0][0]:
-                note = 'Added in API version {}.{}'.format(*version)
-            else:
-                note = 'Modified in API version {}.{}'.format(*version)
-            if 'description' in schema:
-                schema['description'] += '\n\n' + note
-            else:
-                schema['description'] = note
+            if version != (0, 0):
+                try:
+                    schema = object_schema['properties'][self.name]
+                except KeyError:
+                    pass
+                    note = ''
+                if version == self.fields[0][0]:
+                    note = 'Added in API version {}.{}'.format(*version)
+                else:
+                    note = 'Modified in API version {}.{}'.format(*version)
+                if 'description' in schema:
+                    schema['description'] += '\n\n' + note
+                else:
+                    schema['description'] = note
 
     def default_factory(self):
         raise NotImplementedError('default_factory is not implemented yet')

--- a/naucse/converters.py
+++ b/naucse/converters.py
@@ -447,8 +447,9 @@ class Field(AbstractField):
     def after_load(self):
         """Decorate a function that will be called after an attribute is loaded
 
-        The decorated function will be called with one argument: the instance
-        being initialized. (The Field's attribute will already be set on it.)
+        The decorated function will be called with two arguments: the instance
+        being initialized (with the Field's attribute will already be set on
+        it) and the context.
         """
         def _decorator(func):
             self._after_load_hooks.append(func)

--- a/naucse/converters.py
+++ b/naucse/converters.py
@@ -514,10 +514,9 @@ class VersionField(AbstractField):
             field.put_schema_into(object_schema, context)
             if version != (0, 0):
                 try:
-                    schema = object_schema['properties'][self.name]
+                    schema = object_schema['properties'][field.data_key]
                 except KeyError:
-                    pass
-                    note = ''
+                    return
                 if version == self.fields[0][0]:
                     note = 'Added in API version {}.{}'.format(*version)
                 else:

--- a/naucse/models.py
+++ b/naucse/models.py
@@ -313,6 +313,10 @@ class Lesson(Model):
     pk_name = 'slug'
     parent_attrs = ('course', )
 
+    title = VersionField({
+        (0, 2): Field(str, doc='Human-readable lesson title')
+    })
+
     static_files = Field(
         DictConverter(StaticFile, key_arg='filename'),
         factory=dict,
@@ -322,6 +326,11 @@ class Lesson(Model):
         doc="Pages of content. Used for variants (e.g. a page for Linux and "
             + "another for Windows), or non-essential info (e.g. for "
             + "organizers)")
+
+    @pages.after_load()
+    def _set_title(self, context):
+        if self.title is None:
+            self.title = self.pages['index'].title
 
     @property
     def material(self):

--- a/naucse/models.py
+++ b/naucse/models.py
@@ -20,7 +20,7 @@ from naucse.logger import logger
 
 import naucse_render
 
-API_VERSION = 0, 1
+API_VERSION = 0, 2
 
 # XXX: Different timezones?
 _TIMEZONE = 'Europe/Prague'

--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -24,7 +24,11 @@
 {% endif %}
 > <a href="{{ page.lesson.get_url() }}">{{ page.lesson.title }}</a>
 {% if page.slug != 'index' %}
-> {{ page.title }}
+    {% if page.subtitle %}
+        > {{ page.subtitle }}
+    {% else %}
+        > {{ page.title }}
+    {% endif %}
 {% endif %}
 {% endblock %}
 

--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -22,11 +22,10 @@
 {% if page.lesson.material %}
 > <a href="{{ page.lesson.material.session.get_url() }}">{{ page.lesson.material.session.title }}</a>
 {% endif %}
-{% set parent=page.lesson.pages.index %}
-{% if parent and parent != page %}
-> <a href="{{ parent.get_url() }}">{{ parent.title }}</a>
-{% endif %}
+> <a href="{{ page.lesson.get_url() }}">{{ page.lesson.title }}</a>
+{% if page.slug != 'index' %}
 > {{ page.title }}
+{% endif %}
 {% endblock %}
 
 {% block warning_msg %}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='naucse',
-    version='0.1.1',
+    version='0.2',
     description='Website for course materials',
     long_description=Path('README.md').read_text(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
         'lxml',
         'naucse-render',
     ],
+    extras_require={
+        'dev': ['tox', 'pytest'],
+    },
     include_package_data=True,
     zip_safe=False,
 )

--- a/test_naucse/conftest.py
+++ b/test_naucse/conftest.py
@@ -82,7 +82,7 @@ def assert_yaml_dump(data, filename):
             assert data == expected
 
 
-@pytest.fixture(params=((0, 0), (0, 1)))
+@pytest.fixture(params=((0, 0), (0, 1), (0, 2)))
 def assert_model_dump(request):
     version = request.param
     def _assert(model, filename):

--- a/test_naucse/conftest.py
+++ b/test_naucse/conftest.py
@@ -8,6 +8,9 @@ from naucse import models
 from naucse.edit_info import get_local_repo_info
 
 
+API_VERSIONS = ((0, 0), (0, 1), (0, 2))
+
+
 fixture_path = Path(__file__).parent / 'fixtures'
 
 
@@ -82,7 +85,7 @@ def assert_yaml_dump(data, filename):
             assert data == expected
 
 
-@pytest.fixture(params=((0, 0), (0, 1), (0, 2)))
+@pytest.fixture(params=API_VERSIONS)
 def assert_model_dump(request):
     version = request.param
     def _assert(model, filename):

--- a/test_naucse/fixtures/course-data/course-v0.2.yml
+++ b/test_naucse/fixtures/course-data/course-v0.2.yml
@@ -1,0 +1,34 @@
+course:
+    api_version: [0, 2]
+    course:
+        title: A course loaded from API version 0.2
+        subtitle: Suitable for testing only.
+        source_file: courses/complex/info.yml
+        sessions:
+          - slug: first
+            title: First lesson
+            materials:
+              - type: lesson
+                lesson_slug: test/lesson1
+
+lessons:
+    test/lesson1:
+        api_version: [0, 2]
+        data:
+            test/lesson1:
+                pages:
+                    index:
+                        title: A lesson
+                        content: <div>A page</div>
+                        license: cc0
+                        attribution: [me]
+                    subtitled:
+                        title: "A lesson – Subtitled"
+                        content: <div>A page</div>
+                        license: cc0
+                        attribution: [me]
+                    subtitled-and-titled:
+                        title: "A page with custom title"
+                        content: <div>A page</div>
+                        license: cc0
+                        attribution: [me]

--- a/test_naucse/fixtures/course-data/course-v0.2.yml
+++ b/test_naucse/fixtures/course-data/course-v0.2.yml
@@ -16,6 +16,7 @@ lessons:
         api_version: [0, 2]
         data:
             test/lesson1:
+                title: A lesson
                 pages:
                     index:
                         title: A lesson

--- a/test_naucse/fixtures/course-data/course-v0.2.yml
+++ b/test_naucse/fixtures/course-data/course-v0.2.yml
@@ -19,12 +19,11 @@ lessons:
                 title: A lesson
                 pages:
                     index:
-                        title: A lesson
                         content: <div>A page</div>
                         license: cc0
                         attribution: [me]
                     subtitled:
-                        title: "A lesson – Subtitled"
+                        subtitle: Subtitled
                         content: <div>A page</div>
                         license: cc0
                         attribution: [me]

--- a/test_naucse/fixtures/expected-dumps/complex-course.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/complex-course.v0.2.yaml
@@ -1,0 +1,82 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    default_time:
+        end: '22:00'
+        start: 08:00
+    description: blah
+    end_date: '2010-10-20'
+    lessons:
+        test/lesson1:
+            pages:
+                index:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A page
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=index
+            static_files: {}
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+        test/lesson2:
+            pages:
+                index:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: Another page
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson2&page_slug=index
+            static_files: {}
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson2
+    long_description: A <em>fun course!</em>
+    place: Nivnice
+    sessions:
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=empty
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=empty
+        serial: '1'
+        slug: empty
+        title: Empty session
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=empty
+    -   date: '2010-10-20'
+        description: A <em>full session!</em>
+        materials:
+        -   type: special
+        -   external_url: https://somewhere.test/
+            type: link
+            url: https://somewhere.test/
+        -   lesson_slug: test/lesson1
+            type: lesson
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=full
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=full
+        serial: '2'
+        slug: full
+        time:
+            end: '2010-10-20 10:00:00'
+            start: '2010-10-20 09:00:00'
+        title: Full session
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=full
+    source_file: courses/complex/info.yml
+    start_date: '2010-10-20'
+    subtitle: Suitable for testing only.
+    time_description: fortnightly yesteryear
+    title: A complex course
+    url: http://dummy.test/model/web/Course/?course_slug=courses/complex
+    vars:
+        test_var: 123

--- a/test_naucse/fixtures/expected-dumps/complex-course.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/complex-course.v0.2.yaml
@@ -20,6 +20,7 @@ course:
                     title: A page
                     url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=index
             static_files: {}
+            title: A page
             url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
         test/lesson2:
             pages:
@@ -32,6 +33,7 @@ course:
                     title: Another page
                     url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson2&page_slug=index
             static_files: {}
+            title: Another page
             url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson2
     long_description: A <em>fun course!</em>
     place: Nivnice

--- a/test_naucse/fixtures/expected-dumps/course-v0.1.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/course-v0.1.v0.2.yaml
@@ -1,0 +1,48 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    lessons: {}
+    long_description: ''
+    sessions:
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=first
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=first
+        serial: '1'
+        slug: first
+        title: First
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=first
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=second
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=second
+        serial: '2'
+        slug: second
+        title: Second
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=second
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=special
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=special
+        slug: special
+        title: Special
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=special
+    source_file: courses/complex/info.yml
+    subtitle: Suitable for testing only.
+    title: A course loaded from API version 0.1
+    url: http://dummy.test/model/web/Course/?course_slug=courses/complex
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/course-v0.2.v0.0.yaml
+++ b/test_naucse/fixtures/expected-dumps/course-v0.2.v0.0.yaml
@@ -1,0 +1,55 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 0
+course:
+    lessons:
+        test/lesson1:
+            pages:
+                index:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A lesson
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=index
+                subtitled:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: "A lesson \u2013 Subtitled"
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled
+                subtitled-and-titled:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A page with custom title
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled-and-titled
+            static_files: {}
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+    long_description: ''
+    sessions:
+    -   materials:
+        -   lesson_slug: test/lesson1
+            type: lesson
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=first
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=first
+        slug: first
+        title: First lesson
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=first
+    source_file: courses/complex/info.yml
+    subtitle: Suitable for testing only.
+    title: A course loaded from API version 0.2
+    url: http://dummy.test/model/web/Course/?course_slug=courses/complex
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/course-v0.2.v0.1.yaml
+++ b/test_naucse/fixtures/expected-dumps/course-v0.2.v0.1.yaml
@@ -1,0 +1,55 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 1
+course:
+    lessons:
+        test/lesson1:
+            pages:
+                index:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A lesson
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=index
+                subtitled:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: "A lesson \u2013 Subtitled"
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled
+                subtitled-and-titled:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A page with custom title
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled-and-titled
+            static_files: {}
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+    long_description: ''
+    sessions:
+    -   materials:
+        -   lesson_slug: test/lesson1
+            type: lesson
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=first
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=first
+        slug: first
+        title: First lesson
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=first
+    source_file: courses/complex/info.yml
+    subtitle: Suitable for testing only.
+    title: A course loaded from API version 0.2
+    url: http://dummy.test/model/web/Course/?course_slug=courses/complex
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/course-v0.2.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/course-v0.2.v0.2.yaml
@@ -31,6 +31,7 @@ course:
                     title: A page with custom title
                     url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled-and-titled
             static_files: {}
+            title: A lesson
             url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
     long_description: ''
     sessions:

--- a/test_naucse/fixtures/expected-dumps/course-v0.2.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/course-v0.2.v0.2.yaml
@@ -20,6 +20,7 @@ course:
                     license: cc0
                     modules: {}
                     solutions: []
+                    subtitle: Subtitled
                     title: "A lesson \u2013 Subtitled"
                     url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled
                 subtitled-and-titled:

--- a/test_naucse/fixtures/expected-dumps/course-v0.2.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/course-v0.2.v0.2.yaml
@@ -1,0 +1,55 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    lessons:
+        test/lesson1:
+            pages:
+                index:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A lesson
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=index
+                subtitled:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: "A lesson \u2013 Subtitled"
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled
+                subtitled-and-titled:
+                    attribution:
+                    - me
+                    license: cc0
+                    modules: {}
+                    solutions: []
+                    title: A page with custom title
+                    url: http://dummy.test/model/web/Page/?course_slug=courses/complex&lesson_slug=test/lesson1&page_slug=subtitled-and-titled
+            static_files: {}
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+    long_description: ''
+    sessions:
+    -   materials:
+        -   lesson_slug: test/lesson1
+            type: lesson
+            url: http://dummy.test/model/web/Lesson/?course_slug=courses/complex&lesson_slug=test/lesson1
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=back&session_slug=first
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/complex&page_slug=front&session_slug=first
+        slug: first
+        title: First lesson
+        url: http://dummy.test/model/web/Session/?course_slug=courses/complex&session_slug=first
+    source_file: courses/complex/info.yml
+    subtitle: Suitable for testing only.
+    title: A course loaded from API version 0.2
+    url: http://dummy.test/model/web/Course/?course_slug=courses/complex
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/empty-root.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/empty-root.v0.2.yaml
@@ -1,0 +1,8 @@
+$schema: http://dummy.test/schema/Root
+api_version:
+- 0
+- 2
+root:
+    licenses: {}
+    run_years: {}
+    self_study_courses: {}

--- a/test_naucse/fixtures/expected-dumps/minimal-course.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/minimal-course.v0.2.yaml
@@ -1,0 +1,12 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    lessons: {}
+    long_description: ''
+    sessions: []
+    source_file: courses/minimal/info.yml
+    title: A minimal course
+    url: http://dummy.test/model/web/Course/?course_slug=courses/minimal
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/minimal-root.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/minimal-root.v0.2.yaml
@@ -1,0 +1,17 @@
+$schema: http://dummy.test/schema/Root
+api_version:
+- 0
+- 2
+root:
+    licenses:
+        cc-by-sa-40:
+            title: Creative Commons Attribution-ShareAlike 4.0 International
+            url: https://creativecommons.org/licenses/by-sa/4.0/
+        cc0:
+            title: CC0 1.0 Universal Public Domain Dedication
+            url: https://creativecommons.org/publicdomain/zero/1.0/
+    run_years: {}
+    self_study_courses:
+        courses/minimal:
+            $ref: http://dummy.test/model/api/Course/?course_slug=courses/minimal
+    url: http://dummy.test/model/web/Root/?

--- a/test_naucse/fixtures/expected-dumps/normal-course.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/normal-course.v0.2.yaml
@@ -1,0 +1,24 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    lessons: {}
+    long_description: ''
+    sessions:
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/normal-course&page_slug=back&session_slug=normal-lesson
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/normal-course&page_slug=front&session_slug=normal-lesson
+        slug: normal-lesson
+        source_file: courses/normal-course/info.yml
+        title: A normal lesson
+        url: http://dummy.test/model/web/Session/?course_slug=courses/normal-course&session_slug=normal-lesson
+    source_file: courses/normal-course/info.yml
+    title: A plain vanilla course
+    url: http://dummy.test/model/web/Course/?course_slug=courses/normal-course
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/run-with-times.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/run-with-times.v0.2.yaml
@@ -1,0 +1,33 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    default_time:
+        end: '21:00'
+        start: '19:00'
+    end_date: '2000-01-01'
+    lessons: {}
+    long_description: ''
+    sessions:
+    -   date: '2000-01-01'
+        materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=2000/run-with-times&page_slug=back&session_slug=normal-lesson
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=2000/run-with-times&page_slug=front&session_slug=normal-lesson
+        slug: normal-lesson
+        source_file: runs/2000/run-with-times/info.yml
+        time:
+            end: '2000-01-01 21:00:00'
+            start: '2000-01-01 19:00:00'
+        title: A normal lesson
+        url: http://dummy.test/model/web/Session/?course_slug=2000/run-with-times&session_slug=normal-lesson
+    source_file: runs/2000/run-with-times/info.yml
+    start_date: '2000-01-01'
+    title: Test run with scheduled times
+    url: http://dummy.test/model/web/Course/?course_slug=2000/run-with-times
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/run-years/2017.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/run-years/2017.v0.2.yaml
@@ -1,0 +1,7 @@
+$schema: http://dummy.test/schema/RunYear
+api_version:
+- 0
+- 2
+data:
+    2017/multi-year:
+        $ref: http://dummy.test/model/api/Course/?course_slug=2017/multi-year

--- a/test_naucse/fixtures/expected-dumps/run-years/2018.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/run-years/2018.v0.2.yaml
@@ -1,0 +1,7 @@
+$schema: http://dummy.test/schema/RunYear
+api_version:
+- 0
+- 2
+data:
+    2017/multi-year:
+        $ref: http://dummy.test/model/api/Course/?course_slug=2017/multi-year

--- a/test_naucse/fixtures/expected-dumps/run-years/2019.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/run-years/2019.v0.2.yaml
@@ -1,0 +1,9 @@
+$schema: http://dummy.test/schema/RunYear
+api_version:
+- 0
+- 2
+data:
+    2017/multi-year:
+        $ref: http://dummy.test/model/api/Course/?course_slug=2017/multi-year
+    2019/single-session:
+        $ref: http://dummy.test/model/api/Course/?course_slug=2019/single-session

--- a/test_naucse/fixtures/expected-dumps/run-years/root.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/run-years/root.v0.2.yaml
@@ -1,0 +1,23 @@
+$schema: http://dummy.test/schema/Root
+api_version:
+- 0
+- 2
+root:
+    licenses:
+        cc-by-sa-40:
+            title: Creative Commons Attribution-ShareAlike 4.0 International
+            url: https://creativecommons.org/licenses/by-sa/4.0/
+        cc0:
+            title: CC0 1.0 Universal Public Domain Dedication
+            url: https://creativecommons.org/publicdomain/zero/1.0/
+    run_years:
+        2017:
+            $ref: http://dummy.test/model/api/RunYear/?year=2017
+        2018:
+            $ref: http://dummy.test/model/api/RunYear/?year=2018
+        2019:
+            $ref: http://dummy.test/model/api/RunYear/?year=2019
+    self_study_courses:
+        courses/minimal:
+            $ref: http://dummy.test/model/api/Course/?course_slug=courses/minimal
+    url: http://dummy.test/model/web/Root/?

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.0-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.0-in.json
@@ -1,0 +1,187 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    course:
+        description: Collection of sessions
+        properties:
+            default_time:
+                additionalProperties: false
+                description: Default start and end time for sessions
+                properties:
+                    end:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                    start:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                required:
+                - start
+                - end
+                type: object
+            derives:
+                description: Slug of the course this derives from (deprecated)
+                type: string
+            description:
+                description: Short description of the course (about one line).
+                type: string
+            end_date:
+                description: Date when this course ends, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            long_description:
+                description: Long description of the course (up to several paragraphs).
+                format: html-fragment
+                type: string
+            place:
+                description: Human-readable description of the venue
+                type: string
+            sessions:
+                description: Individual sessions
+                items:
+                    $ref: '#/definitions/session'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            start_date:
+                description: Date when this course starts, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            subtitle:
+                description: Human-readable subtitle, mainly used to distinguish several
+                    runs of same-named courses.
+                type: string
+            time_description:
+                description: Human-readable description of the time the course takes
+                    place (e.g. 'Wednesdays')
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            vars:
+                description: Defaults for additional values used for rendering pages
+                type: object
+        required:
+        - title
+        - sessions
+        title: Course
+        type: object
+    material:
+        description: Teaching material, usually a link to a lesson or external page
+        properties:
+            external_url:
+                description: URL for a link to content that's not a naucse lesson
+                format: uri
+                type: string
+            lesson_slug:
+                description: Slug of the corresponding lesson
+                type: string
+            slug:
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            type:
+                description: Type of the material (e.g. lesson, homework, cheatsheet,
+                    link, special). Used for the icon in material lists.
+                type: string
+        required:
+        - type
+        title: Material
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    session:
+        description: 'A smaller collection of teaching materials
+
+
+            Usually used for one meeting of an in-preson course or
+
+            a self-contained section of a longer workshop.'
+        properties:
+            date:
+                description: The date when this session occurs (if it has a set time)
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            description:
+                description: Short description of the session.
+                format: html-fragment
+                type: string
+            materials:
+                description: The session's materials
+                items:
+                    $ref: '#/definitions/material'
+                type: array
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/session-page'
+                description: The session's cover pages
+                type: object
+            slug:
+                type: string
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            time:
+                additionalProperties:
+                    pattern: ^([0-9]{4}-[0-9]{2}-[0-9]{2} )?[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?$
+                    type: string
+                description: Time when this session takes place.
+                required:
+                - start
+                - end
+                type: object
+            title:
+                description: A human-readable session title
+                type: string
+        required:
+        - slug
+        - title
+        title: Session
+        type: object
+    session-page:
+        description: Session-specific page, e.g. the front cover
+        properties:
+            content:
+                description: Content, as HTML
+                format: html-fragment
+                type: string
+        title: SessionPage
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    course:
+        $ref: '#/definitions/course'
+required:
+- course
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.0-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.0-out.json
@@ -1,0 +1,314 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    course:
+        additionalProperties: false
+        description: Collection of sessions
+        properties:
+            default_time:
+                additionalProperties: false
+                description: Default start and end time for sessions
+                properties:
+                    end:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                    start:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                required:
+                - start
+                - end
+                type: object
+            derives:
+                description: Slug of the course this derives from (deprecated)
+                type: string
+            description:
+                description: Short description of the course (about one line).
+                type: string
+            end_date:
+                description: Date when this course ends, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            lessons:
+                additionalProperties:
+                    $ref: '#/definitions/lesson'
+                description: Lessons
+                type: object
+            long_description:
+                description: Long description of the course (up to several paragraphs).
+                format: html-fragment
+                type: string
+            place:
+                description: Human-readable description of the venue
+                type: string
+            sessions:
+                description: Individual sessions
+                items:
+                    $ref: '#/definitions/session'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            start_date:
+                description: Date when this course starts, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            subtitle:
+                description: Human-readable subtitle, mainly used to distinguish several
+                    runs of same-named courses.
+                type: string
+            time_description:
+                description: Human-readable description of the time the course takes
+                    place (e.g. 'Wednesdays')
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+            vars:
+                description: Defaults for additional values used for rendering pages
+                type: object
+        required:
+        - title
+        - sessions
+        title: Course
+        type: object
+    lesson:
+        additionalProperties: false
+        description: "A lesson \u2013 collection of Pages on a single topic"
+        properties:
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/page'
+                description: Pages of content. Used for variants (e.g. a page for
+                    Linux and another for Windows), or non-essential info (e.g. for
+                    organizers)
+                required:
+                - index
+                type: object
+            static_files:
+                additionalProperties:
+                    $ref: '#/definitions/static-file'
+                description: Static files the lesson's content may reference
+                type: object
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - pages
+        title: Lesson
+        type: object
+    material:
+        additionalProperties: false
+        description: Teaching material, usually a link to a lesson or external page
+        properties:
+            external_url:
+                description: URL for a link to content that's not a naucse lesson
+                format: uri
+                type: string
+            lesson_slug:
+                description: Slug of the corresponding lesson
+                type: string
+            slug:
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            type:
+                description: Type of the material (e.g. lesson, homework, cheatsheet,
+                    link, special). Used for the icon in material lists.
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - type
+        title: Material
+        type: object
+    page:
+        additionalProperties: false
+        description: One page of teaching text
+        properties:
+            attribution:
+                description: Lines of attribution, as HTML fragments
+                items:
+                    format: html-fragment
+                    type: string
+                type: array
+            css:
+                contentMediaType: text/css
+                description: CSS specific to this page. (Subject to restrictions which
+                    aren't yet finalized.)
+                type: string
+            license:
+                description: License slugs. Only approved licenses are allowed.
+                type: string
+            license_code:
+                description: Slug of licence for code snippets.
+                type: string
+            modules:
+                additionalProperties:
+                    type: string
+                description: Additional modules as a dict with `slug` key and version
+                    values
+                type: object
+            solutions:
+                description: Solutions to problems that appear on the page.
+                items:
+                    $ref: '#/definitions/solution'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - title
+        - attribution
+        - license
+        title: Page
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    session:
+        additionalProperties: false
+        description: 'A smaller collection of teaching materials
+
+
+            Usually used for one meeting of an in-preson course or
+
+            a self-contained section of a longer workshop.'
+        properties:
+            date:
+                description: The date when this session occurs (if it has a set time)
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            description:
+                description: Short description of the session.
+                format: html-fragment
+                type: string
+            materials:
+                description: The session's materials
+                items:
+                    $ref: '#/definitions/material'
+                type: array
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/session-page'
+                description: The session's cover pages
+                type: object
+            slug:
+                type: string
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            time:
+                additionalProperties:
+                    pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$
+                    type: string
+                description: Time when this session takes place.
+                required:
+                - start
+                - end
+                type: object
+            title:
+                description: A human-readable session title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - slug
+        - title
+        title: Session
+        type: object
+    session-page:
+        additionalProperties: false
+        description: Session-specific page, e.g. the front cover
+        properties:
+            content:
+                description: Content, as HTML
+                format: html-fragment
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        title: SessionPage
+        type: object
+    solution:
+        additionalProperties: false
+        description: Solution to a problem on a Page
+        properties:
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        title: Solution
+        type: object
+    static-file:
+        additionalProperties: false
+        description: Static file specific to a Lesson
+        properties:
+            path:
+                description: Relative path of the file
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - path
+        title: StaticFile
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    course:
+        $ref: '#/definitions/course'
+required:
+- course
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.1-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.1-in.json
@@ -1,0 +1,195 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    course:
+        description: Collection of sessions
+        properties:
+            default_time:
+                additionalProperties: false
+                description: Default start and end time for sessions
+                properties:
+                    end:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                    start:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                required:
+                - start
+                - end
+                type: object
+            derives:
+                description: Slug of the course this derives from (deprecated)
+                type: string
+            description:
+                description: Short description of the course (about one line).
+                type: string
+            end_date:
+                description: Date when this course ends, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            long_description:
+                description: Long description of the course (up to several paragraphs).
+                format: html-fragment
+                type: string
+            place:
+                description: Human-readable description of the venue
+                type: string
+            sessions:
+                description: Individual sessions
+                items:
+                    $ref: '#/definitions/session'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            start_date:
+                description: Date when this course starts, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            subtitle:
+                description: Human-readable subtitle, mainly used to distinguish several
+                    runs of same-named courses.
+                type: string
+            time_description:
+                description: Human-readable description of the time the course takes
+                    place (e.g. 'Wednesdays')
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            vars:
+                description: Defaults for additional values used for rendering pages
+                type: object
+        required:
+        - title
+        - sessions
+        title: Course
+        type: object
+    material:
+        description: Teaching material, usually a link to a lesson or external page
+        properties:
+            external_url:
+                description: URL for a link to content that's not a naucse lesson
+                format: uri
+                type: string
+            lesson_slug:
+                description: Slug of the corresponding lesson
+                type: string
+            slug:
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            type:
+                description: Type of the material (e.g. lesson, homework, cheatsheet,
+                    link, special). Used for the icon in material lists.
+                type: string
+        required:
+        - type
+        title: Material
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    session:
+        description: 'A smaller collection of teaching materials
+
+
+            Usually used for one meeting of an in-preson course or
+
+            a self-contained section of a longer workshop.'
+        properties:
+            date:
+                description: The date when this session occurs (if it has a set time)
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            description:
+                description: Short description of the session.
+                format: html-fragment
+                type: string
+            materials:
+                description: The session's materials
+                items:
+                    $ref: '#/definitions/material'
+                type: array
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/session-page'
+                description: The session's cover pages
+                type: object
+            serial:
+                description: "\n                Human-readable string identifying\
+                    \ the session's position\n                in the course.\n   \
+                    \             The serial is usually numeric: `1`, `2`, `3`, ...,\n\
+                    \                but, for example, i, ii, iii... can be used for\
+                    \ appendices.\n                Some courses start numbering sessions\
+                    \ from 0.\n            \n\nAdded in API version 0.1"
+                type: string
+            slug:
+                type: string
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            time:
+                additionalProperties:
+                    pattern: ^([0-9]{4}-[0-9]{2}-[0-9]{2} )?[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?$
+                    type: string
+                description: Time when this session takes place.
+                required:
+                - start
+                - end
+                type: object
+            title:
+                description: A human-readable session title
+                type: string
+        required:
+        - slug
+        - title
+        title: Session
+        type: object
+    session-page:
+        description: Session-specific page, e.g. the front cover
+        properties:
+            content:
+                description: Content, as HTML
+                format: html-fragment
+                type: string
+        title: SessionPage
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    course:
+        $ref: '#/definitions/course'
+required:
+- course
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.1-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.1-out.json
@@ -1,0 +1,322 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    course:
+        additionalProperties: false
+        description: Collection of sessions
+        properties:
+            default_time:
+                additionalProperties: false
+                description: Default start and end time for sessions
+                properties:
+                    end:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                    start:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                required:
+                - start
+                - end
+                type: object
+            derives:
+                description: Slug of the course this derives from (deprecated)
+                type: string
+            description:
+                description: Short description of the course (about one line).
+                type: string
+            end_date:
+                description: Date when this course ends, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            lessons:
+                additionalProperties:
+                    $ref: '#/definitions/lesson'
+                description: Lessons
+                type: object
+            long_description:
+                description: Long description of the course (up to several paragraphs).
+                format: html-fragment
+                type: string
+            place:
+                description: Human-readable description of the venue
+                type: string
+            sessions:
+                description: Individual sessions
+                items:
+                    $ref: '#/definitions/session'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            start_date:
+                description: Date when this course starts, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            subtitle:
+                description: Human-readable subtitle, mainly used to distinguish several
+                    runs of same-named courses.
+                type: string
+            time_description:
+                description: Human-readable description of the time the course takes
+                    place (e.g. 'Wednesdays')
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+            vars:
+                description: Defaults for additional values used for rendering pages
+                type: object
+        required:
+        - title
+        - sessions
+        title: Course
+        type: object
+    lesson:
+        additionalProperties: false
+        description: "A lesson \u2013 collection of Pages on a single topic"
+        properties:
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/page'
+                description: Pages of content. Used for variants (e.g. a page for
+                    Linux and another for Windows), or non-essential info (e.g. for
+                    organizers)
+                required:
+                - index
+                type: object
+            static_files:
+                additionalProperties:
+                    $ref: '#/definitions/static-file'
+                description: Static files the lesson's content may reference
+                type: object
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - pages
+        title: Lesson
+        type: object
+    material:
+        additionalProperties: false
+        description: Teaching material, usually a link to a lesson or external page
+        properties:
+            external_url:
+                description: URL for a link to content that's not a naucse lesson
+                format: uri
+                type: string
+            lesson_slug:
+                description: Slug of the corresponding lesson
+                type: string
+            slug:
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            type:
+                description: Type of the material (e.g. lesson, homework, cheatsheet,
+                    link, special). Used for the icon in material lists.
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - type
+        title: Material
+        type: object
+    page:
+        additionalProperties: false
+        description: One page of teaching text
+        properties:
+            attribution:
+                description: Lines of attribution, as HTML fragments
+                items:
+                    format: html-fragment
+                    type: string
+                type: array
+            css:
+                contentMediaType: text/css
+                description: CSS specific to this page. (Subject to restrictions which
+                    aren't yet finalized.)
+                type: string
+            license:
+                description: License slugs. Only approved licenses are allowed.
+                type: string
+            license_code:
+                description: Slug of licence for code snippets.
+                type: string
+            modules:
+                additionalProperties:
+                    type: string
+                description: Additional modules as a dict with `slug` key and version
+                    values
+                type: object
+            solutions:
+                description: Solutions to problems that appear on the page.
+                items:
+                    $ref: '#/definitions/solution'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - title
+        - attribution
+        - license
+        title: Page
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    session:
+        additionalProperties: false
+        description: 'A smaller collection of teaching materials
+
+
+            Usually used for one meeting of an in-preson course or
+
+            a self-contained section of a longer workshop.'
+        properties:
+            date:
+                description: The date when this session occurs (if it has a set time)
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            description:
+                description: Short description of the session.
+                format: html-fragment
+                type: string
+            materials:
+                description: The session's materials
+                items:
+                    $ref: '#/definitions/material'
+                type: array
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/session-page'
+                description: The session's cover pages
+                type: object
+            serial:
+                description: "\n                Human-readable string identifying\
+                    \ the session's position\n                in the course.\n   \
+                    \             The serial is usually numeric: `1`, `2`, `3`, ...,\n\
+                    \                but, for example, i, ii, iii... can be used for\
+                    \ appendices.\n                Some courses start numbering sessions\
+                    \ from 0.\n            \n\nAdded in API version 0.1"
+                type: string
+            slug:
+                type: string
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            time:
+                additionalProperties:
+                    pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$
+                    type: string
+                description: Time when this session takes place.
+                required:
+                - start
+                - end
+                type: object
+            title:
+                description: A human-readable session title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - slug
+        - title
+        title: Session
+        type: object
+    session-page:
+        additionalProperties: false
+        description: Session-specific page, e.g. the front cover
+        properties:
+            content:
+                description: Content, as HTML
+                format: html-fragment
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        title: SessionPage
+        type: object
+    solution:
+        additionalProperties: false
+        description: Solution to a problem on a Page
+        properties:
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        title: Solution
+        type: object
+    static-file:
+        additionalProperties: false
+        description: Static file specific to a Lesson
+        properties:
+            path:
+                description: Relative path of the file
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - path
+        title: StaticFile
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    course:
+        $ref: '#/definitions/course'
+required:
+- course
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.2-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.2-in.json
@@ -1,0 +1,195 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    course:
+        description: Collection of sessions
+        properties:
+            default_time:
+                additionalProperties: false
+                description: Default start and end time for sessions
+                properties:
+                    end:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                    start:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                required:
+                - start
+                - end
+                type: object
+            derives:
+                description: Slug of the course this derives from (deprecated)
+                type: string
+            description:
+                description: Short description of the course (about one line).
+                type: string
+            end_date:
+                description: Date when this course ends, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            long_description:
+                description: Long description of the course (up to several paragraphs).
+                format: html-fragment
+                type: string
+            place:
+                description: Human-readable description of the venue
+                type: string
+            sessions:
+                description: Individual sessions
+                items:
+                    $ref: '#/definitions/session'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            start_date:
+                description: Date when this course starts, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            subtitle:
+                description: Human-readable subtitle, mainly used to distinguish several
+                    runs of same-named courses.
+                type: string
+            time_description:
+                description: Human-readable description of the time the course takes
+                    place (e.g. 'Wednesdays')
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            vars:
+                description: Defaults for additional values used for rendering pages
+                type: object
+        required:
+        - title
+        - sessions
+        title: Course
+        type: object
+    material:
+        description: Teaching material, usually a link to a lesson or external page
+        properties:
+            external_url:
+                description: URL for a link to content that's not a naucse lesson
+                format: uri
+                type: string
+            lesson_slug:
+                description: Slug of the corresponding lesson
+                type: string
+            slug:
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            type:
+                description: Type of the material (e.g. lesson, homework, cheatsheet,
+                    link, special). Used for the icon in material lists.
+                type: string
+        required:
+        - type
+        title: Material
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    session:
+        description: 'A smaller collection of teaching materials
+
+
+            Usually used for one meeting of an in-preson course or
+
+            a self-contained section of a longer workshop.'
+        properties:
+            date:
+                description: The date when this session occurs (if it has a set time)
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            description:
+                description: Short description of the session.
+                format: html-fragment
+                type: string
+            materials:
+                description: The session's materials
+                items:
+                    $ref: '#/definitions/material'
+                type: array
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/session-page'
+                description: The session's cover pages
+                type: object
+            serial:
+                description: "\n                Human-readable string identifying\
+                    \ the session's position\n                in the course.\n   \
+                    \             The serial is usually numeric: `1`, `2`, `3`, ...,\n\
+                    \                but, for example, i, ii, iii... can be used for\
+                    \ appendices.\n                Some courses start numbering sessions\
+                    \ from 0.\n            \n\nAdded in API version 0.1"
+                type: string
+            slug:
+                type: string
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            time:
+                additionalProperties:
+                    pattern: ^([0-9]{4}-[0-9]{2}-[0-9]{2} )?[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?$
+                    type: string
+                description: Time when this session takes place.
+                required:
+                - start
+                - end
+                type: object
+            title:
+                description: A human-readable session title
+                type: string
+        required:
+        - slug
+        - title
+        title: Session
+        type: object
+    session-page:
+        description: Session-specific page, e.g. the front cover
+        properties:
+            content:
+                description: Content, as HTML
+                format: html-fragment
+                type: string
+        title: SessionPage
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    course:
+        $ref: '#/definitions/course'
+required:
+- course
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.2-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.2-out.json
@@ -110,11 +110,18 @@ definitions:
                     $ref: '#/definitions/static-file'
                 description: Static files the lesson's content may reference
                 type: object
+            title:
+                description: 'Human-readable lesson title
+
+
+                    Added in API version 0.2'
+                type: string
             url:
                 description: URL for a user-facing page on naucse
                 format: uri
                 type: string
         required:
+        - title
         - pages
         title: Lesson
         type: object

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.2-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.2-out.json
@@ -190,15 +190,23 @@ definitions:
                     to the repository root
                 pattern: ^[^./][^/]*(/[^./][^/]*)*$
                 type: string
+            subtitle:
+                description: "Human-readable subpage title.\n                Required\
+                    \ for index subpages other than \"index\" (unless \"title\"\n\
+                    \                is given).\n                \n\nAdded in API\
+                    \ version 0.2"
+                type: string
             title:
-                description: Human-readable title
+                description: "Human-readable page title.\n\n                Deprecated\
+                    \ since API version 0.2: use lesson.title\n                (and,\
+                    \ for subpages other than index, page.subtitle)\n            \
+                    \    \n\nModified in API version 0.2"
                 type: string
             url:
                 description: URL for a user-facing page on naucse
                 format: uri
                 type: string
         required:
-        - title
         - attribution
         - license
         title: Page

--- a/test_naucse/fixtures/expected-dumps/schema/course-0.2-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/course-0.2-out.json
@@ -1,0 +1,322 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    course:
+        additionalProperties: false
+        description: Collection of sessions
+        properties:
+            default_time:
+                additionalProperties: false
+                description: Default start and end time for sessions
+                properties:
+                    end:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                    start:
+                        pattern: '[0-9]{1,2}:[0-9]{2}'
+                        type: string
+                required:
+                - start
+                - end
+                type: object
+            derives:
+                description: Slug of the course this derives from (deprecated)
+                type: string
+            description:
+                description: Short description of the course (about one line).
+                type: string
+            end_date:
+                description: Date when this course ends, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            lessons:
+                additionalProperties:
+                    $ref: '#/definitions/lesson'
+                description: Lessons
+                type: object
+            long_description:
+                description: Long description of the course (up to several paragraphs).
+                format: html-fragment
+                type: string
+            place:
+                description: Human-readable description of the venue
+                type: string
+            sessions:
+                description: Individual sessions
+                items:
+                    $ref: '#/definitions/session'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            start_date:
+                description: Date when this course starts, or None
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            subtitle:
+                description: Human-readable subtitle, mainly used to distinguish several
+                    runs of same-named courses.
+                type: string
+            time_description:
+                description: Human-readable description of the time the course takes
+                    place (e.g. 'Wednesdays')
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+            vars:
+                description: Defaults for additional values used for rendering pages
+                type: object
+        required:
+        - title
+        - sessions
+        title: Course
+        type: object
+    lesson:
+        additionalProperties: false
+        description: "A lesson \u2013 collection of Pages on a single topic"
+        properties:
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/page'
+                description: Pages of content. Used for variants (e.g. a page for
+                    Linux and another for Windows), or non-essential info (e.g. for
+                    organizers)
+                required:
+                - index
+                type: object
+            static_files:
+                additionalProperties:
+                    $ref: '#/definitions/static-file'
+                description: Static files the lesson's content may reference
+                type: object
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - pages
+        title: Lesson
+        type: object
+    material:
+        additionalProperties: false
+        description: Teaching material, usually a link to a lesson or external page
+        properties:
+            external_url:
+                description: URL for a link to content that's not a naucse lesson
+                format: uri
+                type: string
+            lesson_slug:
+                description: Slug of the corresponding lesson
+                type: string
+            slug:
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            type:
+                description: Type of the material (e.g. lesson, homework, cheatsheet,
+                    link, special). Used for the icon in material lists.
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - type
+        title: Material
+        type: object
+    page:
+        additionalProperties: false
+        description: One page of teaching text
+        properties:
+            attribution:
+                description: Lines of attribution, as HTML fragments
+                items:
+                    format: html-fragment
+                    type: string
+                type: array
+            css:
+                contentMediaType: text/css
+                description: CSS specific to this page. (Subject to restrictions which
+                    aren't yet finalized.)
+                type: string
+            license:
+                description: License slugs. Only approved licenses are allowed.
+                type: string
+            license_code:
+                description: Slug of licence for code snippets.
+                type: string
+            modules:
+                additionalProperties:
+                    type: string
+                description: Additional modules as a dict with `slug` key and version
+                    values
+                type: object
+            solutions:
+                description: Solutions to problems that appear on the page.
+                items:
+                    $ref: '#/definitions/solution'
+                type: array
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            title:
+                description: Human-readable title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - title
+        - attribution
+        - license
+        title: Page
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    session:
+        additionalProperties: false
+        description: 'A smaller collection of teaching materials
+
+
+            Usually used for one meeting of an in-preson course or
+
+            a self-contained section of a longer workshop.'
+        properties:
+            date:
+                description: The date when this session occurs (if it has a set time)
+                format: date
+                pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+                type: string
+            description:
+                description: Short description of the session.
+                format: html-fragment
+                type: string
+            materials:
+                description: The session's materials
+                items:
+                    $ref: '#/definitions/material'
+                type: array
+            pages:
+                additionalProperties:
+                    $ref: '#/definitions/session-page'
+                description: The session's cover pages
+                type: object
+            serial:
+                description: "\n                Human-readable string identifying\
+                    \ the session's position\n                in the course.\n   \
+                    \             The serial is usually numeric: `1`, `2`, `3`, ...,\n\
+                    \                but, for example, i, ii, iii... can be used for\
+                    \ appendices.\n                Some courses start numbering sessions\
+                    \ from 0.\n            \n\nAdded in API version 0.1"
+                type: string
+            slug:
+                type: string
+            source_file:
+                description: Path to a source file containing the page's text, relative
+                    to the repository root
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            time:
+                additionalProperties:
+                    pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$
+                    type: string
+                description: Time when this session takes place.
+                required:
+                - start
+                - end
+                type: object
+            title:
+                description: A human-readable session title
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - slug
+        - title
+        title: Session
+        type: object
+    session-page:
+        additionalProperties: false
+        description: Session-specific page, e.g. the front cover
+        properties:
+            content:
+                description: Content, as HTML
+                format: html-fragment
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        title: SessionPage
+        type: object
+    solution:
+        additionalProperties: false
+        description: Solution to a problem on a Page
+        properties:
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        title: Solution
+        type: object
+    static-file:
+        additionalProperties: false
+        description: Static file specific to a Lesson
+        properties:
+            path:
+                description: Relative path of the file
+                pattern: ^[^./][^/]*(/[^./][^/]*)*$
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - path
+        title: StaticFile
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    course:
+        $ref: '#/definitions/course'
+required:
+- course
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/root-0.0-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/root-0.0-in.json
@@ -1,0 +1,75 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    license:
+        description: A license for content or code
+        properties:
+            title:
+                type: string
+            url:
+                type: string
+        required:
+        - url
+        - title
+        title: License
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    root:
+        description: 'Data for the naucse website
+
+
+            Contains a collection of courses plus additional metadata.'
+        properties:
+            licenses:
+                additionalProperties:
+                    $ref: '#/definitions/license'
+                description: Allowed licenses
+                type: object
+            run_years:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: Links to courses by year
+                type: object
+            self_study_courses:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: "Links to \"canonical\" courses \u2013 ones without a\
+                    \ time span"
+                type: object
+        required:
+        - self_study_courses
+        - run_years
+        - licenses
+        title: Root
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    root:
+        $ref: '#/definitions/root'
+required:
+- root
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/root-0.0-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/root-0.0-out.json
@@ -1,0 +1,83 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    license:
+        additionalProperties: false
+        description: A license for content or code
+        properties:
+            title:
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - url
+        - title
+        title: License
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    root:
+        additionalProperties: false
+        description: 'Data for the naucse website
+
+
+            Contains a collection of courses plus additional metadata.'
+        properties:
+            licenses:
+                additionalProperties:
+                    $ref: '#/definitions/license'
+                description: Allowed licenses
+                type: object
+            run_years:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: Links to courses by year
+                type: object
+            self_study_courses:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: "Links to \"canonical\" courses \u2013 ones without a\
+                    \ time span"
+                type: object
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - self_study_courses
+        - run_years
+        - licenses
+        title: Root
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    root:
+        $ref: '#/definitions/root'
+required:
+- root
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/root-0.1-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/root-0.1-in.json
@@ -1,0 +1,75 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    license:
+        description: A license for content or code
+        properties:
+            title:
+                type: string
+            url:
+                type: string
+        required:
+        - url
+        - title
+        title: License
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    root:
+        description: 'Data for the naucse website
+
+
+            Contains a collection of courses plus additional metadata.'
+        properties:
+            licenses:
+                additionalProperties:
+                    $ref: '#/definitions/license'
+                description: Allowed licenses
+                type: object
+            run_years:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: Links to courses by year
+                type: object
+            self_study_courses:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: "Links to \"canonical\" courses \u2013 ones without a\
+                    \ time span"
+                type: object
+        required:
+        - self_study_courses
+        - run_years
+        - licenses
+        title: Root
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    root:
+        $ref: '#/definitions/root'
+required:
+- root
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/root-0.1-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/root-0.1-out.json
@@ -1,0 +1,83 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    license:
+        additionalProperties: false
+        description: A license for content or code
+        properties:
+            title:
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - url
+        - title
+        title: License
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    root:
+        additionalProperties: false
+        description: 'Data for the naucse website
+
+
+            Contains a collection of courses plus additional metadata.'
+        properties:
+            licenses:
+                additionalProperties:
+                    $ref: '#/definitions/license'
+                description: Allowed licenses
+                type: object
+            run_years:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: Links to courses by year
+                type: object
+            self_study_courses:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: "Links to \"canonical\" courses \u2013 ones without a\
+                    \ time span"
+                type: object
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - self_study_courses
+        - run_years
+        - licenses
+        title: Root
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    root:
+        $ref: '#/definitions/root'
+required:
+- root
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/root-0.2-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/root-0.2-in.json
@@ -1,0 +1,75 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    license:
+        description: A license for content or code
+        properties:
+            title:
+                type: string
+            url:
+                type: string
+        required:
+        - url
+        - title
+        title: License
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    root:
+        description: 'Data for the naucse website
+
+
+            Contains a collection of courses plus additional metadata.'
+        properties:
+            licenses:
+                additionalProperties:
+                    $ref: '#/definitions/license'
+                description: Allowed licenses
+                type: object
+            run_years:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: Links to courses by year
+                type: object
+            self_study_courses:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: "Links to \"canonical\" courses \u2013 ones without a\
+                    \ time span"
+                type: object
+        required:
+        - self_study_courses
+        - run_years
+        - licenses
+        title: Root
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    root:
+        $ref: '#/definitions/root'
+required:
+- root
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/root-0.2-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/root-0.2-out.json
@@ -1,0 +1,83 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    license:
+        additionalProperties: false
+        description: A license for content or code
+        properties:
+            title:
+                type: string
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - url
+        - title
+        title: License
+        type: object
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+    root:
+        additionalProperties: false
+        description: 'Data for the naucse website
+
+
+            Contains a collection of courses plus additional metadata.'
+        properties:
+            licenses:
+                additionalProperties:
+                    $ref: '#/definitions/license'
+                description: Allowed licenses
+                type: object
+            run_years:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: Links to courses by year
+                type: object
+            self_study_courses:
+                additionalProperties:
+                    $ref: '#/definitions/ref'
+                description: "Links to \"canonical\" courses \u2013 ones without a\
+                    \ time span"
+                type: object
+            url:
+                description: URL for a user-facing page on naucse
+                format: uri
+                type: string
+        required:
+        - self_study_courses
+        - run_years
+        - licenses
+        title: Root
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    root:
+        $ref: '#/definitions/root'
+required:
+- root
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/run-year-0.0-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/run-year-0.0-in.json
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    data:
+        additionalProperties:
+            $ref: '#/definitions/ref'
+        type: object
+required:
+- data
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/run-year-0.0-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/run-year-0.0-out.json
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    data:
+        additionalProperties:
+            $ref: '#/definitions/ref'
+        type: object
+required:
+- data
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/run-year-0.1-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/run-year-0.1-in.json
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    data:
+        additionalProperties:
+            $ref: '#/definitions/ref'
+        type: object
+required:
+- data
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/run-year-0.1-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/run-year-0.1-out.json
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    data:
+        additionalProperties:
+            $ref: '#/definitions/ref'
+        type: object
+required:
+- data
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/run-year-0.2-in.json
+++ b/test_naucse/fixtures/expected-dumps/schema/run-year-0.2-in.json
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    data:
+        additionalProperties:
+            $ref: '#/definitions/ref'
+        type: object
+required:
+- data
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/schema/run-year-0.2-out.json
+++ b/test_naucse/fixtures/expected-dumps/schema/run-year-0.2-out.json
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-06/schema#
+additionalProperties: false
+definitions:
+    api_version:
+        description: "Version of the information, and of the schema,\nas two integers\
+            \ \u2013 [major, minor].\nThe minor version is increased on every change\
+            \ to the\nschema that keeps backwards compatibility for forks\n(i.e. input\
+            \ data).\nThe major version is increased on incompatible changes.\n\n\
+            Version 0.x means incompatible changes may be done at any\ntime. Please\
+            \ coordinate your use of the API with us."
+        items:
+            type: integer
+        maxItems: 2
+        minItems: 2
+        type: array
+    ref:
+        additionalProperties: false
+        description: URL to the data (in JSON format)
+        properties:
+            $ref:
+                format: uri
+                type: string
+        type: object
+properties:
+    $schema:
+        format: uri
+        type: string
+    api_version:
+        $ref: '#/definitions/api_version'
+    data:
+        additionalProperties:
+            $ref: '#/definitions/ref'
+        type: object
+required:
+- data
+- api_version
+type: object

--- a/test_naucse/fixtures/expected-dumps/session-times/with-default-times.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/session-times/with-default-times.v0.2.yaml
@@ -1,0 +1,72 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    default_time:
+        end: '21:00'
+        start: '19:00'
+    end_date: '2000-01-01'
+    lessons: {}
+    long_description: ''
+    sessions:
+    -   date: '2000-01-01'
+        materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=back&session_slug=normal-session
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=front&session_slug=normal-session
+        serial: '1'
+        slug: normal-session
+        time:
+            end: '2000-01-01 21:00:00'
+            start: '2000-01-01 19:00:00'
+        title: A normal session
+        url: http://dummy.test/model/web/Session/?course_slug=courses/with-default-times&session_slug=normal-session
+    -   date: '2000-01-01'
+        materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=back&session_slug=afterparty
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=front&session_slug=afterparty
+        serial: '2'
+        slug: afterparty
+        time:
+            end: '2000-01-01 23:00:00'
+            start: '2000-01-01 22:00:00'
+        title: Afterparty (with overridden time)
+        url: http://dummy.test/model/web/Session/?course_slug=courses/with-default-times&session_slug=afterparty
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=back&session_slug=self-study
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=front&session_slug=self-study
+        serial: '3'
+        slug: self-study
+        title: Self-study (no date)
+        url: http://dummy.test/model/web/Session/?course_slug=courses/with-default-times&session_slug=self-study
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=back&session_slug=morning-meditation
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/with-default-times&page_slug=front&session_slug=morning-meditation
+        serial: '4'
+        slug: morning-meditation
+        title: Umm... no date, but a time
+        url: http://dummy.test/model/web/Session/?course_slug=courses/with-default-times&session_slug=morning-meditation
+    start_date: '2000-01-01'
+    title: Test course with default times
+    url: http://dummy.test/model/web/Course/?course_slug=courses/with-default-times
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/session-times/without-dates.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/session-times/without-dates.v0.2.yaml
@@ -1,0 +1,22 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    lessons: {}
+    long_description: ''
+    sessions:
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-dates&page_slug=back&session_slug=normal-session
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-dates&page_slug=front&session_slug=normal-session
+        slug: normal-session
+        title: A normal session
+        url: http://dummy.test/model/web/Session/?course_slug=courses/without-dates&session_slug=normal-session
+    title: A plain vanilla course
+    url: http://dummy.test/model/web/Course/?course_slug=courses/without-dates
+    vars: {}

--- a/test_naucse/fixtures/expected-dumps/session-times/without-default-time.v0.2.yaml
+++ b/test_naucse/fixtures/expected-dumps/session-times/without-default-time.v0.2.yaml
@@ -1,0 +1,66 @@
+$schema: http://dummy.test/schema/Course
+api_version:
+- 0
+- 2
+course:
+    end_date: '2000-01-01'
+    lessons: {}
+    long_description: ''
+    sessions:
+    -   date: '2000-01-01'
+        materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=back&session_slug=normal-session
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=front&session_slug=normal-session
+        serial: '1'
+        slug: normal-session
+        title: A normal session
+        url: http://dummy.test/model/web/Session/?course_slug=courses/without-default-time&session_slug=normal-session
+    -   date: '2000-01-01'
+        materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=back&session_slug=afterparty
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=front&session_slug=afterparty
+        serial: '2'
+        slug: afterparty
+        time:
+            end: '2000-01-01 23:00:00'
+            start: '2000-01-01 22:00:00'
+        title: Afterparty (with overridden time)
+        url: http://dummy.test/model/web/Session/?course_slug=courses/without-default-time&session_slug=afterparty
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=back&session_slug=self-study
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=front&session_slug=self-study
+        serial: '3'
+        slug: self-study
+        title: Self-study (no date)
+        url: http://dummy.test/model/web/Session/?course_slug=courses/without-default-time&session_slug=self-study
+    -   materials: []
+        pages:
+            back:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=back&session_slug=morning-meditation
+            front:
+                content: ''
+                url: http://dummy.test/model/web/SessionPage/?course_slug=courses/without-default-time&page_slug=front&session_slug=morning-meditation
+        serial: '4'
+        slug: morning-meditation
+        title: Umm... no date, but a time
+        url: http://dummy.test/model/web/Session/?course_slug=courses/without-default-time&session_slug=morning-meditation
+    start_date: '2000-01-01'
+    title: Test course without scheduled times
+    url: http://dummy.test/model/web/Course/?course_slug=courses/without-default-time
+    vars: {}

--- a/test_naucse/test_course.py
+++ b/test_naucse/test_course.py
@@ -149,8 +149,8 @@ def test_complex_course(model, assert_model_dump):
     assert course.sessions['full'].description == 'A <em>full session!</em>'
 
 
-def test_api_1_0(model, assert_model_dump):
-    """Valid complex json that could come from a fork is loaded correctly"""
+def test_api_0_1(model, assert_model_dump):
+    """Valid complex json with API 0.1 is loaded correctly"""
     course = load_course_from_fixture(model, 'course-data/course-v0.1.yml')
 
     assert_model_dump(course, 'course-v0.1')

--- a/test_naucse/test_course.py
+++ b/test_naucse/test_course.py
@@ -149,11 +149,13 @@ def test_complex_course(model, assert_model_dump):
     assert course.sessions['full'].description == 'A <em>full session!</em>'
 
 
-def test_api_0_1(model, assert_model_dump):
-    """Valid complex json with API 0.1 is loaded correctly"""
-    course = load_course_from_fixture(model, 'course-data/course-v0.1.yml')
+@pytest.mark.parametrize('version', ('0.1', '0.2'))
+def test_api_version(model, assert_model_dump, version):
+    """Valid json with API changes from the given version is loaded correctly"""
+    name = f'course-v{version}'
+    course = load_course_from_fixture(model, f'course-data/{name}.yml')
 
-    assert_model_dump(course, 'course-v0.1')
+    assert_model_dump(course, name)
 
 
 def test_derives(model):

--- a/test_naucse/test_schema.py
+++ b/test_naucse/test_schema.py
@@ -1,0 +1,17 @@
+import pytest
+
+from naucse import models
+
+from test_naucse.conftest import assert_yaml_dump, API_VERSIONS
+
+
+@pytest.mark.parametrize('version', API_VERSIONS)
+@pytest.mark.parametrize('mode', ('in', 'out'))
+@pytest.mark.parametrize(
+    'cls', (models.Root, models.RunYear, models.Course))
+def test_schema_unchanged(model, version, mode, cls):
+    """Test that the API schema did not change"""
+    schema = models.get_schema(
+        cls, is_input=(mode == 'in'), version=version,
+    )
+    assert_yaml_dump(schema, f'schema/{cls.model_slug}-{version[0]}.{version[1]}-{mode}.json')


### PR DESCRIPTION
* Set API version to 0.2
* A collection of various fixes in the converters
* Add `title` to lesson and `subtitle` for page for https://github.com/pyvec/naucse/issues/20

This is `naucse` part of `naucse_render`'s https://github.com/pyvec/naucse_render/pull/12.
Note that input from older `naucse_render` (API 0.1) is still usable. However, output only publishes API 0.2.

In addition to this, I'll want to add timezone support (https://github.com/pyvec/naucse/issues/13) and tweak slugs (https://github.com/pyvec/naucse/issues/12) before the next release. However, it turns out timezones are complicated (who knew?) and this is already big enough. I'll leave those to another PR.
