### PR TITLE
Add UNIX timestamp to generated website.

### DIFF
--- a/naucse/views.py
+++ b/naucse/views.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 from pathlib import Path
 import functools
 import calendar
@@ -427,3 +428,12 @@ def course_api(course_slug):
     except KeyError:
         abort(404)
     return jsonify(models.dump(course, version=models.API_VERSION))
+
+
+@app.route('/v0/timestamp.json')
+def timestamp():
+    """
+    UNIX timestamp which will be fixed during freeze.
+    It is used for invalidating remote caches of the generated JSON API.
+    """
+    return jsonify(int(time.time()))


### PR DESCRIPTION
Adds a UNIX timestamp to the generated website, so that it can be used by remote sites (like https://github.com/messa/pyladies-courseware) to invalidate their caches if something changes.

The timestamp is global for the whole website to keep it simple (pyladies-courseware fetches the whole website in one go, so this change is enough to solve its caching problem).

If you want to use a hash instead, we could add a simple postprocessing step to `naucse`, which would hash the `v0` directory after the website is frozen and create a file containing the hash inside the `v0` directory.

Related issues: https://github.com/pyvec/naucse/issues/28, https://github.com/messa/pyladies-courseware/issues/165