### PR TITLE
converters: Disallow duplicate keys in KeyAttrDictConverter

### DIFF
--- a/naucse/converters.py
+++ b/naucse/converters.py
@@ -48,6 +48,10 @@ import inspect
 import jsonschema
 
 
+class DuplicateKeyError(ValueError):
+    """A mapping with duplicate keys was specified"""
+
+
 class BaseConverter:
     """Converts to/from JSON-compatible values and provides JSON schema
 
@@ -258,7 +262,10 @@ class KeyAttrDictConverter(BaseConverter):
             if self.index_arg:
                 kwargs[self.index_arg] = index
             item = self.item_converter.load(value, context, **kwargs)
-            result[getattr(item, self.key_attr)] = item
+            key = getattr(item, self.key_attr)
+            if key in result:
+                raise DuplicateKeyError(f'Duplicate key: {key}')
+            result[key] = item
         return result
 
     def dump(self, value, context):

--- a/test_naucse/fixtures/course-data/invalid-duplicate-session.yml
+++ b/test_naucse/fixtures/course-data/invalid-duplicate-session.yml
@@ -1,0 +1,9 @@
+course:
+    api_version: [0, 0]
+    course:
+        title: An invalid course
+        sessions:
+          - slug: duplicate
+            title: "A session"
+          - slug: duplicate
+            title: "A session"

--- a/test_naucse/test_course.py
+++ b/test_naucse/test_course.py
@@ -6,6 +6,7 @@ from jsonschema.exceptions import ValidationError
 
 from naucse import models
 from naucse.edit_info import get_local_repo_info
+from naucse.converters import DuplicateKeyError
 
 from test_naucse.conftest import add_test_course, fixture_path
 
@@ -195,3 +196,9 @@ def test_invalid_course(model):
     """Invalid complex json that could come from a fork is not loaded"""
     with pytest.raises(ValidationError):
         load_course_from_fixture(model, 'course-data/invalid-course.yml')
+
+
+def test_invalid_duplicate_session(model):
+    """Json with duplicate sessions that could come from a fork is not loaded"""
+    with pytest.raises(DuplicateKeyError):
+        load_course_from_fixture(model, 'course-data/invalid-duplicate-session.yml')


### PR DESCRIPTION
Fixes: https://github.com/pyvec/naucse/issues/2

This will break with old courses if they have duplicate keys. But if that's the case, I want to know about it – and fix them, even if they're archived.
