### PR TITLE
Add 'title' to the allowed HTML attributes

### DIFF
--- a/naucse/sanitize.py
+++ b/naucse/sanitize.py
@@ -56,6 +56,7 @@ ALLOWED_ATTRIBUTES = {
     'class',
     'id',   # XXX: validate id's
     'aria-hidden',
+    'title',
 }
 PER_TAG_ATTRIBUTES = {
     'a': {'href'},


### PR DESCRIPTION
Looks like it's generated by this Markdown:
```markdown
![thumb_geografie.png](static/thumb_geografie.png "Sheet 1")
```

Ideally this would give `alt`, but `title` is harmless.