### PR TITLE
Style Notebook error output

### DIFF
--- a/naucse/static/css/ipython.css
+++ b/naucse/static/css/ipython.css
@@ -75,6 +75,10 @@ div.output_subarea, div.inner_cell {
   flex: 1;
 }
 
+div.input_area pre {
+  margin-bottom: 0;
+}
+
 div.output_area pre {
   margin: 0;
   padding: 0;
@@ -87,6 +91,11 @@ div.output_area pre {
 
 div.output_subarea {
   padding: 0.4em;
+}
+
+div.output_stderr {
+  background: #fdd;
+  /* very light red background for stderr */
 }
 
 /** Table styles adapted from


### PR DESCRIPTION
This colors stderr light red and puts it next to the input area:

![image](https://user-images.githubusercontent.com/302922/104190406-5a8dec00-541c-11eb-8cdd-0ef503380f6b.png)

It also puts other outputs closer to inputs, which isn't bad:

![image](https://user-images.githubusercontent.com/302922/104190622-a3de3b80-541c-11eb-8c4d-07199e4fb2f2.png)

Fixes: https://github.com/pyvec/naucse/issues/27
A more long-term solution is tracked in https://github.com/pyvec/naucse_render/issues/21