### PR TITLE
Add compatibility with Jinja2 3.0

### DIFF
--- a/naucse/sanitize.py
+++ b/naucse/sanitize.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlsplit, urlunsplit, parse_qsl
 import re
 
-from jinja2 import Markup
+from markupsafe import Markup
 import lxml.html
 import lxml.etree
 import cssutils

--- a/naucse/templates.py
+++ b/naucse/templates.py
@@ -1,4 +1,5 @@
-from jinja2 import Markup, StrictUndefined
+from markupsafe import Markup
+from jinja2 import StrictUndefined
 import mistune
 
 from .sanitize import sanitize_html

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='naucse',
-    version='0.3',
+    version='0.3.1',
     description='Website for course materials',
     long_description=Path('README.md').read_text(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'naucse-render',
         'backports.zoneinfo; python_version<"3.9"',
         'tzdata; sys_platform=="win32"',
+        'markupsafe',
     ],
     extras_require={
         'dev': ['tox', 'pytest'],


### PR DESCRIPTION
With jinja2 3.0.0, `Markup` should be imported from `markupsafe`, rather than from `jinja2`.

<s>Also: test on Python 3.10 – it's unlikely that things will break until 3.10.0 comes out.</s>