### PR TITLE
Fix & test git_identifer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build
 .pytest_cache
 /.tox
 /dist/
+/.hypothesis/

--- a/naucse/compiled_renderer.py
+++ b/naucse/compiled_renderer.py
@@ -194,14 +194,14 @@ def git_identifer(string):
             return result
         num = ord(char)
         if num < 2**8:
-            return '-c{num:02x}'
+            return f'-c{num:02x}'
         if num < 2**16:
-            return '-u{num:04x}'
+            return f'-u{num:04x}'
         if num < 2**32:
-            return '-v{num:016x}'
+            return f'-v{num:08x}'
         raise ValueError('char to big')
     result = re.sub('[^a-z0-9]', replacement, string)
-    if re.match('^[a-z]', result):
+    if re.match('^[a-z]', result) and not result.startswith('x'):
         return result
     else:
         return 'x' + result

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,4 @@ install_requires =
 dev =
     tox
     pytest
+    hypothesis

--- a/test_naucse/test_git_identifier.py
+++ b/test_naucse/test_git_identifier.py
@@ -1,0 +1,37 @@
+import re
+
+import pytest
+from hypothesis import given, example
+from hypothesis.strategies import text
+
+from naucse.compiled_renderer import git_identifer
+
+# The variable names are case-insensitive -> use only lowercase.
+# Allow only alphanumeric characters and -, and start with
+# an alphabetic character
+IDENTIFIER_RE = re.compile('^[a-z][a-z0-9-]*$')
+
+@given(text())
+def test_git_identifer_valid(text):
+    result = git_identifer(text)
+    assert IDENTIFIER_RE.match(result)
+
+
+@given(text(), text())
+@example('0', 'x0')
+def test_git_identifers_different(text1, text2):
+    """Identifiers from different strings must be different"""
+    if text1 == text2:
+        assert git_identifer(text1) == git_identifer(text2)
+    else:
+        assert git_identifer(text1) != git_identifer(text2)
+
+
+@pytest.mark.parametrize(('input', 'output'), (
+    ('simple', 'simple'),
+    ('CaPiTaL', 'x-c43a-c50i-c54a-c4c'),
+    ('→Fünny 😸 letters\0!', 'x-u2192-c46-cfcnny-c20-v0001f638-c20letters-c00-c21'),
+    ('yap:/foo.bar/a-b_c/', 'yap-m-sfoo-pbar-sa-db-rc-s'),
+))
+def test_git_identifer_example(input, output):
+    assert git_identifer(input) == output

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 envlist = py38,py39,310
 
 [testenv]
+extras = dev
 deps = pytest
 commands=python -m pytest test_naucse


### PR DESCRIPTION
Alas, what's not tested is broken.
The function misbehaved with capital letters, and a few edge cases.
Let's throw some property-based testing at it.