### PR TITLE
Fix styling of the <kbd> tag

### DIFF
--- a/naucse/static/css/body.css
+++ b/naucse/static/css/body.css
@@ -13,7 +13,7 @@ hr.lesson-end {
     margin-top: 6rem;
 }
 
-p kbd {
+kbd {
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-bottom-width: 3px;


### PR DESCRIPTION
`<kbd>` should always be styled nicely, even if it doesn't appear in `<p>`.
---
Before:
![image](https://user-images.githubusercontent.com/302922/188641703-f7d77afc-c7ec-4d2d-a6d8-f39cc72ff5ad.png)
After:
![image](https://user-images.githubusercontent.com/302922/188641734-e255d6f2-fa16-425f-829e-2fb3d3c06df5.png)
